### PR TITLE
Migration to RC18 and compilation fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion = "1.0.0-RC17"
+val zioVersion = "1.0.0-RC18-2"
 libraryDependencies ++= Seq(
   "dev.zio" %% "zio"          % zioVersion,
   "dev.zio" %% "zio-test"     % zioVersion % "test",

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -54,9 +54,10 @@ object BuildHelper {
           "-opt-warnings",
           "-Ywarn-extra-implicit",
           "-Ywarn-unused:_,imports",
-          "-Ywarn-unused:imports",
-          "-opt:l:inline",
-          "-opt-inline-from:<source>"
+          "-Ywarn-unused:imports"
+//        enable in 2.12.11 (https://github.com/scala/bug/issues/11671)
+//          "-opt:l:inline",
+//          "-opt-inline-from:<source>"
         ) ++ stdOptsUpto212
       case _ =>
         Seq("-Xexperimental") ++ stdOptsUpto212

--- a/src/test/scala/zio/concurrent/HelloWorldSpec.scala
+++ b/src/test/scala/zio/concurrent/HelloWorldSpec.scala
@@ -13,14 +13,13 @@ object HelloWorld {
     console.putStrLn("Hello, World!")
 }
 
-object HelloWorldSpec
-    extends DefaultRunnableSpec(
-      suite("HelloWorldSpec")(
-        testM("sayHello correctly displays output") {
-          for {
-            _      <- sayHello
-            output <- TestConsole.output
-          } yield assert(output, equalTo(Vector("Hello, World!\n")))
-        }
-      )
-    )
+object HelloWorldSpec extends DefaultRunnableSpec {
+  val spec = suite("HelloWorldSpec")(
+    testM("sayHello correctly displays output") {
+      for {
+        _      <- sayHello
+        output <- TestConsole.output
+      } yield assert(output)(equalTo(Vector("Hello, World!\n")))
+    }
+  )
+}


### PR DESCRIPTION
* Migration to RC18
* Make it compile again (remove `-opt` flag). Should be reenabled again after https://github.com/scala/bug/issues/11671 will be released with 2.12.11